### PR TITLE
fix error bad URI(is not URI?) if url contains vertical bar

### DIFF
--- a/lib/teamlab/request.rb
+++ b/lib/teamlab/request.rb
@@ -33,7 +33,7 @@ module Teamlab
 
     def request(type, args)
       command, opts = parse_args(args, type)
-      url = generate_request_url(command)
+      url = URI.encode(generate_request_url(command))
       attempts = 0
       begin
         response = Teamlab::Response.new(HTTMultiParty.send(type, url, opts))


### PR DESCRIPTION
example url: http://example.com/api/2.0/files/file/sbox-62449-||test.docx